### PR TITLE
GH001: Update ECC patches following JDK-8226374

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2022-07-04  Andrew John Hughes  <gnu_andrew@member.fsf.org>
+
+	* NEWS: Updated.
+	* patches/gh001-3curve.patch: Renamed
+	from pr3818-3curve.patch. Updated to
+	apply after JDK-8226374, including
+	removal of unsupported curve from
+	jdk.tls.disabledAlgorithms.
+	* patches/gh001-4curve.patch: Likewise
+	for the 4 curve version, renamed from
+	pr3818-4curve.patch
+
 2021-02-21  Andrew John Hughes  <gnu_andrew@member.fsf.org>
 
 	PR3833: Update tapsets following JDK-8015774,

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ DX  - http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=X
 GX  - http://bugs.gentoo.org/show_bug.cgi?id=X
 CAX - http://server.complang.tuwien.ac.at/cgi-bin/bugzilla/show_bug.cgi?id=X
 LPX - https://bugs.launchpad.net/bugs/X
+GHX - https://github.com/icedtea-git/icedtea/issues/X
 
 CVE-XXXX-YYYY: http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=XXXX-YYYY
 
@@ -22,6 +23,8 @@ New in release 6.0.0 (2019-XX-XX):
   - PR3829: arc_priority representation creates an implicit limit on character sequence within regexp
   - PR3831: Hotspot object_alloc tapset uses HeapWordSize incorrectly
   - PR3833, RH1814915: Update tapsets following JDK-8015774, which removes '_heap'
+* Bug fixes
+  - GH001: Update ECC patch, following JDK-8226374
 
 New in release 5.0.0 (2019-XX-XX):
 

--- a/patches/gh001-3curve.patch
+++ b/patches/gh001-3curve.patch
@@ -1,7 +1,14 @@
+commit 203e6ef0ca871133c06b07f7da56779627c2139b
+Author: Andrew Hughes <gnu.andrew@redhat.com>
+Date:   Thu Jul 15 02:29:27 2021 +0100
+
+    Limit elliptic curve cryptography support (3 curves: secp256r1, secp384r1, secp521r1)
+
 diff --git a/make/lib/Lib-jdk.crypto.ec.gmk b/make/lib/Lib-jdk.crypto.ec.gmk
+index dfecc1d3cb..9ec74b80fd 100644
 --- a/make/lib/Lib-jdk.crypto.ec.gmk
 +++ b/make/lib/Lib-jdk.crypto.ec.gmk
-@@ -43,7 +43,7 @@
+@@ -43,7 +43,7 @@ ifeq ($(ENABLE_INTREE_EC), true)
        TOOLCHAIN := TOOLCHAIN_LINK_CXX, \
        OPTIMIZATION := LOW, \
        CFLAGS := $(BUILD_LIBSUNEC_CFLAGS_JDKLIB) \
@@ -11,125 +18,155 @@ diff --git a/make/lib/Lib-jdk.crypto.ec.gmk b/make/lib/Lib-jdk.crypto.ec.gmk
        DISABLED_WARNINGS_gcc := sign-compare implicit-fallthrough, \
        DISABLED_WARNINGS_microsoft := 4101 4244 4146 4018, \
 diff --git a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
+index 7b5fca3190..aba656ad02 100644
 --- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
 +++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
-@@ -50,93 +50,7 @@
+@@ -49,119 +49,6 @@ enum NamedGroup {
      // Elliptic Curves (RFC 4492)
      //
      // See sun.security.util.CurveDB for the OIDs
 -    // NIST K-163
 -
--    SECT163_K1(0x0001, "sect163k1", "1.3.132.0.1", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT163_R1(0x0002, "sect163r1", "1.3.132.0.2", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT163_K1(0x0001, "sect163k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect163k1")),
+-    SECT163_R1(0x0002, "sect163r1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect163r1")),
 -
 -    // NIST B-163
--    SECT163_R2(0x0003, "sect163r2", "1.3.132.0.15", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT193_R1(0x0004, "sect193r1", "1.3.132.0.24", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT193_R2(0x0005, "sect193r2", "1.3.132.0.25", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT163_R2(0x0003, "sect163r2", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect163r2")),
+-    SECT193_R1(0x0004, "sect193r1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect193r1")),
+-    SECT193_R2(0x0005, "sect193r2", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect193r2")),
 -
 -    // NIST K-233
--    SECT233_K1(0x0006, "sect233k1", "1.3.132.0.26", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT233_K1(0x0006, "sect233k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect233k1")),
 -
 -    // NIST B-233
--    SECT233_R1(0x0007, "sect233r1", "1.3.132.0.27", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT239_K1(0x0008, "sect239k1", "1.3.132.0.3", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT233_R1(0x0007, "sect233r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect233r1")),
+-    SECT239_K1(0x0008, "sect239k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect239k1")),
 -
 -    // NIST K-283
--    SECT283_K1(0x0009, "sect283k1", "1.3.132.0.16", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT283_K1(0x0009, "sect283k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect283k1")),
 -
 -    // NIST B-283
--    SECT283_R1(0x000A, "sect283r1", "1.3.132.0.17", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT283_R1(0x000A, "sect283r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect283r1")),
 -
 -    // NIST K-409
--    SECT409_K1(0x000B, "sect409k1", "1.3.132.0.36", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT409_K1(0x000B, "sect409k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect409k1")),
 -
 -    // NIST B-409
--    SECT409_R1(0x000C, "sect409r1", "1.3.132.0.37", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT409_R1(0x000C, "sect409r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect409r1")),
 -
 -    // NIST K-571
--    SECT571_K1(0x000D, "sect571k1", "1.3.132.0.38", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT571_K1(0x000D, "sect571k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect571k1")),
 -
 -    // NIST B-571
--    SECT571_R1(0x000E, "sect571r1", "1.3.132.0.39", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP160_K1(0x000F, "secp160k1", "1.3.132.0.9", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP160_R1(0x0010, "secp160r1", "1.3.132.0.8", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP160_R2(0x0011, "secp160r2", "1.3.132.0.30", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP192_K1(0x0012, "secp192k1", "1.3.132.0.31", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT571_R1(0x000E, "sect571r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect571r1")),
+-    SECP160_K1(0x000F, "secp160k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp160k1")),
+-    SECP160_R1(0x0010, "secp160r1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp160r1")),
+-    SECP160_R2(0x0011, "secp160r2", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp160r2")),
+-    SECP192_K1(0x0012, "secp192k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp192k1")),
 -
 -    // NIST P-192
--    SECP192_R1(0x0013, "secp192r1", "1.2.840.10045.3.1.1", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP224_K1(0x0014, "secp224k1", "1.3.132.0.32", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECP192_R1(0x0013, "secp192r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp192r1")),
+-    SECP224_K1(0x0014, "secp224k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp224k1")),
 -
-     // NIST P-224
--    SECP224_R1(0x0015, "secp224r1", "1.3.132.0.33", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
-     SECP256_K1(0x0016, "secp256k1", "1.3.132.0.10", false,
-             NamedGroupType.NAMED_GROUP_ECDHE,
-             ProtocolVersion.PROTOCOLS_TO_12),
-@@ -179,17 +93,7 @@
-             ProtocolVersion.PROTOCOLS_TO_13),
-     FFDHE_8192(0x0104, "ffdhe8192", null, true,
-             NamedGroupType.NAMED_GROUP_FFDHE,
--            ProtocolVersion.PROTOCOLS_TO_13),
+-    // NIST P-224
+-    SECP224_R1(0x0015, "secp224r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp224r1")),
+-    SECP256_K1(0x0016, "secp256k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp256k1")),
+-
+     // NIST P-256
+     SECP256_R1(0x0017, "secp256r1", true,
+             NamedGroupSpec.NAMED_GROUP_ECDHE,
+@@ -211,19 +98,7 @@ enum NamedGroup {
+     FFDHE_8192(0x0104, "ffdhe8192", true,
+             NamedGroupSpec.NAMED_GROUP_FFDHE,
+             ProtocolVersion.PROTOCOLS_TO_13,
+-            PredefinedDHParameterSpecs.ffdheParams.get(8192)),
 -
 -    // Elliptic Curves (RFC 4492)
 -    //
 -    // arbitrary prime and characteristic-2 curves
--    ARBITRARY_PRIME(0xFF01, "arbitrary_explicit_prime_curves", null, false,
--            NamedGroupType.NAMED_GROUP_ARBITRARY,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    ARBITRARY_CHAR2(0xFF02, "arbitrary_explicit_char2_curves", null, false,
--            NamedGroupType.NAMED_GROUP_ARBITRARY,
--            ProtocolVersion.PROTOCOLS_TO_12);
-+            ProtocolVersion.PROTOCOLS_TO_13);
+-    ARBITRARY_PRIME(0xFF01, "arbitrary_explicit_prime_curves", false,
+-            NamedGroupSpec.NAMED_GROUP_ARBITRARY,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            null),
+-    ARBITRARY_CHAR2(0xFF02, "arbitrary_explicit_char2_curves", false,
+-            NamedGroupSpec.NAMED_GROUP_ARBITRARY,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            null);
++            PredefinedDHParameterSpecs.ffdheParams.get(8192));
  
      final int id;               // hash + signature
-     final NamedGroupType type;  // group type
+     final String name;          // literal name
 diff --git a/src/java.base/share/classes/sun/security/util/CurveDB.java b/src/java.base/share/classes/sun/security/util/CurveDB.java
+index 7e6f62fe5a..591c533adb 100644
 --- a/src/java.base/share/classes/sun/security/util/CurveDB.java
 +++ b/src/java.base/share/classes/sun/security/util/CurveDB.java
-@@ -176,105 +176,6 @@
+@@ -176,114 +176,6 @@ public class CurveDB {
          Pattern nameSplitPattern = Holder.nameSplitPattern;
  
          /* SEC2 prime curves */
@@ -232,10 +269,19 @@ diff --git a/src/java.base/share/classes/sun/security/util/CurveDB.java b/src/ja
 -            "FFFFFFFFFFFFFFFFFFFFFFFFFFFF16A2E0B8F03E13DD29455C5C2A3D",
 -            1, nameSplitPattern);
 -
-         add("secp256k1", "1.3.132.0.10", P,
-             "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
-             "0000000000000000000000000000000000000000000000000000000000000000",
-@@ -311,435 +212,6 @@
+-        add("secp256k1", "1.3.132.0.10", P,
+-            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+-            "0000000000000000000000000000000000000000000000000000000000000000",
+-            "0000000000000000000000000000000000000000000000000000000000000007",
+-            "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+-            "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+-            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+-            1, nameSplitPattern);
+-
+         add("secp256r1 [NIST P-256, X9.62 prime256v1]", "1.2.840.10045.3.1.7", PD,
+             "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF",
+             "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC",
+@@ -311,435 +203,6 @@ public class CurveDB {
              "01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA51868783BF2F966B7FCC0148F709A5D03BB5C9B8899C47AEBB6FB71E91386409",
              1, nameSplitPattern);
  
@@ -672,9 +718,10 @@ diff --git a/src/java.base/share/classes/sun/security/util/CurveDB.java b/src/ja
      }
  }
 diff --git a/src/java.base/share/conf/security/java.security b/src/java.base/share/conf/security/java.security
+index efbaa5be9c..28d2215f41 100644
 --- a/src/java.base/share/conf/security/java.security
 +++ b/src/java.base/share/conf/security/java.security
-@@ -504,16 +504,7 @@
+@@ -504,16 +504,7 @@ sun.security.krb5.maxReferrals=5
  # in the jdk.[tls|certpath|jar].disabledAlgorithms properties.  To include this
  # list in any of the disabledAlgorithms properties, add the property name as
  # an entry.
@@ -688,17 +735,29 @@ diff --git a/src/java.base/share/conf/security/java.security b/src/java.base/sha
 -    X9.62 c2tnb359v1, X9.62 c2tnb431r1, X9.62 prime192v2, X9.62 prime192v3, \
 -    X9.62 prime239v1, X9.62 prime239v2, X9.62 prime239v3, brainpoolP256r1, \
 -    brainpoolP320r1, brainpoolP384r1, brainpoolP512r1
-+jdk.disabled.namedCurves = secp256k1
++jdk.disabled.namedCurves = 
  
  #
  # Algorithm restrictions for certification path (CertPath) processing
+@@ -749,7 +740,7 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
+ #
+ # Example:
+ #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048, \
+-#       rsa_pkcs1_sha1, secp224r1
++#       rsa_pkcs1_sha1
+ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
+     DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+     include jdk.disabled.namedCurves
 diff --git a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java b/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java
+index 41a100ad7e..9dfc4dd780 100644
 --- a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java
 +++ b/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java
-@@ -161,149 +161,6 @@
+@@ -159,162 +159,6 @@ public final class ECDSAUtils {
+     private static final List<ECCurveDefinition> ecCurveDefinitions = new ArrayList<>();
+ 
      static {
-         ecCurveDefinitions.add(
-                 new ECCurveDefinition(
+-        ecCurveDefinitions.add(
+-                new ECCurveDefinition(
 -                        "secp112r1",
 -                        "1.3.132.0.6",
 -                        "db7c2abf62e35e668076bead208b",
@@ -842,10 +901,21 @@ diff --git a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/s
 -
 -        ecCurveDefinitions.add(
 -                new ECCurveDefinition(
-                         "secp256k1",
-                         "1.3.132.0.10",
-                         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-@@ -353,409 +210,6 @@
+-                        "secp256k1",
+-                        "1.3.132.0.10",
+-                        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+-                        "0000000000000000000000000000000000000000000000000000000000000000",
+-                        "0000000000000000000000000000000000000000000000000000000000000007",
+-                        "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+-                        "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+-                        "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+-                        1)
+-        );
+-
+         ecCurveDefinitions.add(
+                 new ECCurveDefinition(
+                         "secp256r1 [NIST P-256, X9.62 prime256v1]",
+@@ -353,409 +197,6 @@ public final class ECDSAUtils {
                          "01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
                          1)
          );
@@ -1256,6 +1326,7 @@ diff --git a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/s
  
      public static String getOIDFromPublicKey(ECPublicKey ecPublicKey) {
 diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h
+index aaa75e5d2d..648b56fc30 100644
 --- a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h
 +++ b/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h
 @@ -44,25 +44,6 @@
@@ -1284,7 +1355,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
  
  static const ECCurveParams ecCurve_NIST_P256 = {
          "NIST-P256", ECField_GFp, 256,
-@@ -96,411 +77,7 @@
+@@ -96,637 +77,70 @@ static const ECCurveParams ecCurve_NIST_P521 = {
          1
  };
  
@@ -1602,7 +1673,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 -        "0340340340340340340340340340340340340340340340340340340323C313FAB50589703B5EC68D3587FEC60D161CC149C1AD4A91", 0x2760
 -};
 -
- /* SEC2 prime curves */
+-/* SEC2 prime curves */
 -static const ECCurveParams ecCurve_SECG_PRIME_112R1 = {
 -        "SECP-112R1", ECField_GFp, 112,
 -        "DB7C2ABF62E35E668076BEAD208B",
@@ -1693,13 +1764,16 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 -        "010000000000000000000000000001DCE8D2EC6184CAF0A971769FB1F7", 1
 -};
 -
- static const ECCurveParams ecCurve_SECG_PRIME_256K1 = {
-         "SECP-256K1", ECField_GFp, 256,
-         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
-@@ -511,222 +88,70 @@
-         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 1
- };
- 
+-static const ECCurveParams ecCurve_SECG_PRIME_256K1 = {
+-        "SECP-256K1", ECField_GFp, 256,
+-        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+-        "0000000000000000000000000000000000000000000000000000000000000000",
+-        "0000000000000000000000000000000000000000000000000000000000000007",
+-        "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+-        "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+-        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 1
+-};
+-
 -/* SEC2 binary curves */
 -static const ECCurveParams ecCurve_SECG_CHAR2_113R1 = {
 -        "SECT-113R1", ECField_GF2m, 113,
@@ -1902,47 +1976,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 -    &ecCurve_SECG_PRIME_160R2,          /* ECCurve_SECG_PRIME_160R2 */
 -    &ecCurve_SECG_PRIME_192K1,          /* ECCurve_SECG_PRIME_192K1 */
 -    &ecCurve_SECG_PRIME_224K1,          /* ECCurve_SECG_PRIME_224K1 */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-     &ecCurve_SECG_PRIME_256K1,          /* ECCurve_SECG_PRIME_256K1 */
+-    &ecCurve_SECG_PRIME_256K1,          /* ECCurve_SECG_PRIME_256K1 */
 -    &ecCurve_SECG_CHAR2_113R1,          /* ECCurve_SECG_CHAR2_113R1 */
 -    &ecCurve_SECG_CHAR2_113R2,          /* ECCurve_SECG_CHAR2_113R2 */
 -    &ecCurve_SECG_CHAR2_131R1,          /* ECCurve_SECG_CHAR2_131R1 */
@@ -1973,10 +2007,52 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 +    NULL,                               /* ECCurve_noName */
 +    NULL,                               /* ECCurve_noName */
 +    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
      NULL                                /* ECCurve_pastLastCurve */
  };
  
 diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c b/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c
+index 49f407a28b..2006aeda79 100644
 --- a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c
 +++ b/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c
 @@ -39,7 +39,6 @@
@@ -1987,7 +2063,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c b/src/jdk.crypto
  #include "ecp.h"
  #ifndef _KERNEL
  #include <stdlib.h>
-@@ -170,50 +169,6 @@
+@@ -170,50 +169,6 @@ ECGroup_consGFp_mont(const mp_int *irr, const mp_int *curvea,
          return group;
  }
  
@@ -2038,7 +2114,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c b/src/jdk.crypto
  /* Construct ECGroup from hex parameters and name, if any. Called by
   * ECGroup_fromHex and ECGroup_fromName. */
  ECGroup *
-@@ -254,85 +209,10 @@
+@@ -254,85 +209,10 @@ ecgroup_fromNameAndHex(const ECCurveName name,
  
          /* determine which optimizations (if any) to use */
          if (params->field == ECField_GFp) {
@@ -2125,9 +2201,10 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c b/src/jdk.crypto
                  res = MP_UNDEF;
                  goto CLEANUP;
 diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c
+index 3d899dcf1f..5c0eee1e12 100644
 --- a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c
 +++ b/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c
-@@ -73,87 +73,13 @@
+@@ -73,87 +73,12 @@
  /* NOTE: prime192v1 is the same as secp192r1, prime256v1 is the
   * same as secp256r1
   */
@@ -2150,7 +2227,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -CONST_OID secgECsecp192k1[] = { SECG_OID, 0x1f };
 -CONST_OID secgECsecp224k1[] = { SECG_OID, 0x20 };
 -CONST_OID secgECsecp224r1[] = { SECG_OID, 0x21 };
- CONST_OID secgECsecp256k1[] = { SECG_OID, 0x0a };
+-CONST_OID secgECsecp256k1[] = { SECG_OID, 0x0a };
  CONST_OID secgECsecp384r1[] = { SECG_OID, 0x22 };
  CONST_OID secgECsecp521r1[] = { SECG_OID, 0x23 };
  
@@ -2215,7 +2292,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
  #define OI(x) { siDEROID, (unsigned char *)x, sizeof x }
  #ifndef SECOID_NO_STRINGS
  #define OD(oid,tag,desc,mech,ext) { OI(oid), tag, desc, mech, ext }
-@@ -174,30 +100,18 @@
+@@ -174,30 +99,18 @@ static SECOidData ANSI_prime_oids[] = {
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
  
@@ -2258,7 +2335,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
      OD( ansiX962prime256v1, ECCurve_NIST_P256,
          "ANSI X9.62 elliptic curve prime256v1 (aka secp256r1, NIST P-256)",
          CKM_INVALID_MECHANISM,
-@@ -208,42 +122,24 @@
+@@ -208,46 +121,6 @@ static SECOidData SECG_oids[] = {
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
  
@@ -2298,91 +2375,36 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -        "SECG elliptic curve secp160k1",
 -        CKM_INVALID_MECHANISM,
 -        INVALID_CERT_EXTENSION ),
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-     OD( secgECsecp256k1, ECCurve_SECG_PRIME_256K1,
-         "SECG elliptic curve secp256k1",
-         CKM_INVALID_MECHANISM,
-@@ -256,16 +152,50 @@
+-    OD( secgECsecp256k1, ECCurve_SECG_PRIME_256K1,
+-        "SECG elliptic curve secp256k1",
+-        CKM_INVALID_MECHANISM,
+-        INVALID_CERT_EXTENSION ),
+     { { siDEROID, NULL, 0 }, ECCurve_noName,
+         "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
+     { { siDEROID, NULL, 0 }, ECCurve_noName,
+@@ -256,18 +129,6 @@ static SECOidData SECG_oids[] = {
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 -    OD( secgECsect163r2, ECCurve_NIST_B163,
 -        "SECG elliptic curve sect163r2 (aka NIST B-163)",
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    OD( secgECsecp384r1, ECCurve_NIST_P384,
-+        "SECG elliptic curve secp384r1 (aka NIST P-384)",
-         CKM_INVALID_MECHANISM,
-         INVALID_CERT_EXTENSION ),
+-        CKM_INVALID_MECHANISM,
+-        INVALID_CERT_EXTENSION ),
 -    OD( secgECsect283k1, ECCurve_NIST_K283,
 -        "SECG elliptic curve sect283k1 (aka NIST K-283)",
 -        CKM_INVALID_MECHANISM,
 -        INVALID_CERT_EXTENSION ),
 -    OD( secgECsect283r1, ECCurve_NIST_B283,
 -        "SECG elliptic curve sect283r1 (aka NIST B-283)",
-+    OD( secgECsecp521r1, ECCurve_NIST_P521,
-+        "SECG elliptic curve secp521r1 (aka NIST P-521)",
-         CKM_INVALID_MECHANISM,
-         INVALID_CERT_EXTENSION ),
-     { { siDEROID, NULL, 0 }, ECCurve_noName,
-@@ -275,79 +205,7 @@
+-        CKM_INVALID_MECHANISM,
+-        INVALID_CERT_EXTENSION ),
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
--        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
+@@ -276,54 +137,56 @@ static SECOidData SECG_oids[] = {
+         "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
+     { { siDEROID, NULL, 0 }, ECCurve_noName,
+         "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 -    OD( secgECsect131r1, ECCurve_SECG_CHAR2_131R1,
 -        "SECG elliptic curve sect131r1",
 -        CKM_INVALID_MECHANISM,
@@ -2431,14 +2453,63 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -        "SECG elliptic curve secp224r1 (aka NIST P-224)",
 -        CKM_INVALID_MECHANISM,
 -        INVALID_CERT_EXTENSION ),
--    OD( secgECsecp384r1, ECCurve_NIST_P384,
--        "SECG elliptic curve secp384r1 (aka NIST P-384)",
--        CKM_INVALID_MECHANISM,
--        INVALID_CERT_EXTENSION ),
--    OD( secgECsecp521r1, ECCurve_NIST_P521,
--        "SECG elliptic curve secp521r1 (aka NIST P-521)",
--        CKM_INVALID_MECHANISM,
--        INVALID_CERT_EXTENSION ),
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
+     OD( secgECsecp384r1, ECCurve_NIST_P384,
+         "SECG elliptic curve secp384r1 (aka NIST P-384)",
+         CKM_INVALID_MECHANISM,
+@@ -332,22 +195,14 @@ static SECOidData SECG_oids[] = {
+         "SECG elliptic curve secp521r1 (aka NIST P-521)",
+         CKM_INVALID_MECHANISM,
+         INVALID_CERT_EXTENSION ),
 -    OD( secgECsect409k1, ECCurve_NIST_K409,
 -        "SECG elliptic curve sect409k1 (aka NIST K-409)",
 -        CKM_INVALID_MECHANISM,
@@ -2455,11 +2526,18 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -        "SECG elliptic curve sect571r1 (aka NIST B-571)",
 -        CKM_INVALID_MECHANISM,
 -        INVALID_CERT_EXTENSION )
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
 +        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION }
  };
  
  static SECOidData ANSI_oids[] = {
-@@ -355,78 +213,46 @@
+@@ -355,78 +210,46 @@ static SECOidData ANSI_oids[] = {
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
  
      /* ANSI X9.62 named elliptic curves (characteristic two field) */
@@ -2491,22 +2569,6 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -        "ANSI X9.62 elliptic curve c2tnb191v3",
 -        CKM_INVALID_MECHANISM,
 -        INVALID_CERT_EXTENSION ),
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
@@ -2527,12 +2589,6 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -        "ANSI X9.62 elliptic curve c2tnb239v3",
 -        CKM_INVALID_MECHANISM,
 -        INVALID_CERT_EXTENSION ),
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
@@ -2566,11 +2622,33 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 +    { { siDEROID, NULL, 0 }, ECCurve_noName,
 +        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 +    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
 +        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION }
  };
  
  static SECOidData BRAINPOOL_oids[] = {
-@@ -446,31 +272,14 @@
+@@ -446,31 +269,14 @@ static SECOidData BRAINPOOL_oids[] = {
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
@@ -2604,6 +2682,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
  
  int
 diff --git a/test/jdk/sun/security/ec/TestEC.java b/test/jdk/sun/security/ec/TestEC.java
+index eb15af75cb..f3ef4fafb1 100644
 --- a/test/jdk/sun/security/ec/TestEC.java
 +++ b/test/jdk/sun/security/ec/TestEC.java
 @@ -37,8 +37,8 @@
@@ -2618,6 +2697,7 @@ diff --git a/test/jdk/sun/security/ec/TestEC.java b/test/jdk/sun/security/ec/Tes
  
  import java.security.NoSuchProviderException;
 diff --git a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
+index 43efcd5afb..8389a688a1 100644
 --- a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
 +++ b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
 @@ -34,9 +34,9 @@

--- a/patches/gh001-4curve.patch
+++ b/patches/gh001-4curve.patch
@@ -13,127 +13,146 @@ diff --git a/make/lib/Lib-jdk.crypto.ec.gmk b/make/lib/Lib-jdk.crypto.ec.gmk
 diff --git a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
 --- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
 +++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
-@@ -50,97 +50,6 @@
+@@ -49,114 +49,7 @@
      // Elliptic Curves (RFC 4492)
      //
      // See sun.security.util.CurveDB for the OIDs
 -    // NIST K-163
 -
--    SECT163_K1(0x0001, "sect163k1", "1.3.132.0.1", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT163_R1(0x0002, "sect163r1", "1.3.132.0.2", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT163_K1(0x0001, "sect163k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect163k1")),
+-    SECT163_R1(0x0002, "sect163r1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect163r1")),
 -
 -    // NIST B-163
--    SECT163_R2(0x0003, "sect163r2", "1.3.132.0.15", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT193_R1(0x0004, "sect193r1", "1.3.132.0.24", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT193_R2(0x0005, "sect193r2", "1.3.132.0.25", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT163_R2(0x0003, "sect163r2", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect163r2")),
+-    SECT193_R1(0x0004, "sect193r1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect193r1")),
+-    SECT193_R2(0x0005, "sect193r2", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect193r2")),
 -
 -    // NIST K-233
--    SECT233_K1(0x0006, "sect233k1", "1.3.132.0.26", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT233_K1(0x0006, "sect233k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect233k1")),
 -
 -    // NIST B-233
--    SECT233_R1(0x0007, "sect233r1", "1.3.132.0.27", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECT239_K1(0x0008, "sect239k1", "1.3.132.0.3", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT233_R1(0x0007, "sect233r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect233r1")),
+-    SECT239_K1(0x0008, "sect239k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect239k1")),
 -
 -    // NIST K-283
--    SECT283_K1(0x0009, "sect283k1", "1.3.132.0.16", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT283_K1(0x0009, "sect283k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect283k1")),
 -
 -    // NIST B-283
--    SECT283_R1(0x000A, "sect283r1", "1.3.132.0.17", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT283_R1(0x000A, "sect283r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect283r1")),
 -
 -    // NIST K-409
--    SECT409_K1(0x000B, "sect409k1", "1.3.132.0.36", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT409_K1(0x000B, "sect409k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect409k1")),
 -
 -    // NIST B-409
--    SECT409_R1(0x000C, "sect409r1", "1.3.132.0.37", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT409_R1(0x000C, "sect409r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect409r1")),
 -
 -    // NIST K-571
--    SECT571_K1(0x000D, "sect571k1", "1.3.132.0.38", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT571_K1(0x000D, "sect571k1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect571k1")),
 -
 -    // NIST B-571
--    SECT571_R1(0x000E, "sect571r1", "1.3.132.0.39", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP160_K1(0x000F, "secp160k1", "1.3.132.0.9", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP160_R1(0x0010, "secp160r1", "1.3.132.0.8", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP160_R2(0x0011, "secp160r2", "1.3.132.0.30", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP192_K1(0x0012, "secp192k1", "1.3.132.0.31", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECT571_R1(0x000E, "sect571r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("sect571r1")),
+-    SECP160_K1(0x000F, "secp160k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp160k1")),
+-    SECP160_R1(0x0010, "secp160r1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp160r1")),
+-    SECP160_R2(0x0011, "secp160r2", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp160r2")),
+-    SECP192_K1(0x0012, "secp192k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp192k1")),
 -
 -    // NIST P-192
--    SECP192_R1(0x0013, "secp192r1", "1.2.840.10045.3.1.1", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP224_K1(0x0014, "secp224k1", "1.3.132.0.32", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
+-    SECP192_R1(0x0013, "secp192r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp192r1")),
+-    SECP224_K1(0x0014, "secp224k1", false,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp224k1")),
 -
--    // NIST P-224
--    SECP224_R1(0x0015, "secp224r1", "1.3.132.0.33", true,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    SECP256_K1(0x0016, "secp256k1", "1.3.132.0.10", false,
--            NamedGroupType.NAMED_GROUP_ECDHE,
--            ProtocolVersion.PROTOCOLS_TO_12),
--
-     // NIST P-256
-     SECP256_R1(0x0017, "secp256r1", "1.2.840.10045.3.1.7", true,
-             NamedGroupType.NAMED_GROUP_ECDHE,
-@@ -179,17 +88,7 @@
-             ProtocolVersion.PROTOCOLS_TO_13),
-     FFDHE_8192(0x0104, "ffdhe8192", null, true,
-             NamedGroupType.NAMED_GROUP_FFDHE,
--            ProtocolVersion.PROTOCOLS_TO_13),
+     // NIST P-224
+-    SECP224_R1(0x0015, "secp224r1", true,
+-            NamedGroupSpec.NAMED_GROUP_ECDHE,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            CurveDB.lookup("secp224r1")),
+     SECP256_K1(0x0016, "secp256k1", false,
+             NamedGroupSpec.NAMED_GROUP_ECDHE,
+             ProtocolVersion.PROTOCOLS_TO_12,
+@@ -211,19 +104,7 @@
+     FFDHE_8192(0x0104, "ffdhe8192", true,
+             NamedGroupSpec.NAMED_GROUP_FFDHE,
+             ProtocolVersion.PROTOCOLS_TO_13,
+-            PredefinedDHParameterSpecs.ffdheParams.get(8192)),
 -
 -    // Elliptic Curves (RFC 4492)
 -    //
 -    // arbitrary prime and characteristic-2 curves
--    ARBITRARY_PRIME(0xFF01, "arbitrary_explicit_prime_curves", null, false,
--            NamedGroupType.NAMED_GROUP_ARBITRARY,
--            ProtocolVersion.PROTOCOLS_TO_12),
--    ARBITRARY_CHAR2(0xFF02, "arbitrary_explicit_char2_curves", null, false,
--            NamedGroupType.NAMED_GROUP_ARBITRARY,
--            ProtocolVersion.PROTOCOLS_TO_12);
-+            ProtocolVersion.PROTOCOLS_TO_13);
+-    ARBITRARY_PRIME(0xFF01, "arbitrary_explicit_prime_curves", false,
+-            NamedGroupSpec.NAMED_GROUP_ARBITRARY,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            null),
+-    ARBITRARY_CHAR2(0xFF02, "arbitrary_explicit_char2_curves", false,
+-            NamedGroupSpec.NAMED_GROUP_ARBITRARY,
+-            ProtocolVersion.PROTOCOLS_TO_12,
+-            null);
++	    PredefinedDHParameterSpecs.ffdheParams.get(8192));
  
      final int id;               // hash + signature
-     final NamedGroupType type;  // group type
+     final String name;          // literal name
 diff --git a/src/java.base/share/classes/sun/security/util/CurveDB.java b/src/java.base/share/classes/sun/security/util/CurveDB.java
 --- a/src/java.base/share/classes/sun/security/util/CurveDB.java
 +++ b/src/java.base/share/classes/sun/security/util/CurveDB.java
-@@ -176,114 +176,6 @@
+@@ -176,105 +176,6 @@
          Pattern nameSplitPattern = Holder.nameSplitPattern;
  
          /* SEC2 prime curves */
@@ -236,19 +255,10 @@ diff --git a/src/java.base/share/classes/sun/security/util/CurveDB.java b/src/ja
 -            "FFFFFFFFFFFFFFFFFFFFFFFFFFFF16A2E0B8F03E13DD29455C5C2A3D",
 -            1, nameSplitPattern);
 -
--        add("secp256k1", "1.3.132.0.10", P,
--            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
--            "0000000000000000000000000000000000000000000000000000000000000000",
--            "0000000000000000000000000000000000000000000000000000000000000007",
--            "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
--            "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
--            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
--            1, nameSplitPattern);
--
-         add("secp256r1 [NIST P-256, X9.62 prime256v1]", "1.2.840.10045.3.1.7", PD,
-             "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF",
-             "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC",
-@@ -311,435 +203,6 @@
+         add("secp256k1", "1.3.132.0.10", P,
+             "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+             "0000000000000000000000000000000000000000000000000000000000000000",
+@@ -311,435 +212,6 @@
              "01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA51868783BF2F966B7FCC0148F709A5D03BB5C9B8899C47AEBB6FB71E91386409",
              1, nameSplitPattern);
  
@@ -701,14 +711,23 @@ diff --git a/src/java.base/share/conf/security/java.security b/src/java.base/sha
 -    X9.62 c2tnb359v1, X9.62 c2tnb431r1, X9.62 prime192v2, X9.62 prime192v3, \
 -    X9.62 prime239v1, X9.62 prime239v2, X9.62 prime239v3, brainpoolP256r1, \
 -    brainpoolP320r1, brainpoolP384r1, brainpoolP512r1
-+jdk.disabled.namedCurves = 
++jdk.disabled.namedCurves = secp256k1
  
  #
  # Algorithm restrictions for certification path (CertPath) processing
+@@ -749,7 +740,7 @@
+ #
+ # Example:
+ #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048, \
+-#       rsa_pkcs1_sha1, secp224r1
++#       rsa_pkcs1_sha1
+ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
+     DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+     include jdk.disabled.namedCurves
 diff --git a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java b/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java
 --- a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java
 +++ b/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/algorithms/implementations/ECDSAUtils.java
-@@ -161,162 +161,6 @@
+@@ -161,149 +161,6 @@
      static {
          ecCurveDefinitions.add(
                  new ECCurveDefinition(
@@ -855,23 +874,10 @@ diff --git a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/s
 -
 -        ecCurveDefinitions.add(
 -                new ECCurveDefinition(
--                        "secp256k1",
--                        "1.3.132.0.10",
--                        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
--                        "0000000000000000000000000000000000000000000000000000000000000000",
--                        "0000000000000000000000000000000000000000000000000000000000000007",
--                        "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
--                        "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
--                        "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
--                        1)
--        );
--
--        ecCurveDefinitions.add(
--                new ECCurveDefinition(
-                         "secp256r1 [NIST P-256, X9.62 prime256v1]",
-                         "1.2.840.10045.3.1.7",
-                         "ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-@@ -353,409 +197,6 @@
+                         "secp256k1",
+                         "1.3.132.0.10",
+                         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+@@ -353,409 +210,6 @@
                          "01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
                          1)
          );
@@ -1310,7 +1316,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
  
  static const ECCurveParams ecCurve_NIST_P256 = {
          "NIST-P256", ECField_GFp, 256,
-@@ -96,637 +77,70 @@
+@@ -96,411 +77,7 @@
          1
  };
  
@@ -1628,7 +1634,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 -        "0340340340340340340340340340340340340340340340340340340323C313FAB50589703B5EC68D3587FEC60D161CC149C1AD4A91", 0x2760
 -};
 -
--/* SEC2 prime curves */
+ /* SEC2 prime curves */
 -static const ECCurveParams ecCurve_SECG_PRIME_112R1 = {
 -        "SECP-112R1", ECField_GFp, 112,
 -        "DB7C2ABF62E35E668076BEAD208B",
@@ -1719,16 +1725,13 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 -        "010000000000000000000000000001DCE8D2EC6184CAF0A971769FB1F7", 1
 -};
 -
--static const ECCurveParams ecCurve_SECG_PRIME_256K1 = {
--        "SECP-256K1", ECField_GFp, 256,
--        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
--        "0000000000000000000000000000000000000000000000000000000000000000",
--        "0000000000000000000000000000000000000000000000000000000000000007",
--        "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
--        "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
--        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 1
--};
--
+ static const ECCurveParams ecCurve_SECG_PRIME_256K1 = {
+         "SECP-256K1", ECField_GFp, 256,
+         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+@@ -511,222 +88,70 @@
+         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 1
+ };
+ 
 -/* SEC2 binary curves */
 -static const ECCurveParams ecCurve_SECG_CHAR2_113R1 = {
 -        "SECT-113R1", ECField_GF2m, 113,
@@ -1931,7 +1934,47 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 -    &ecCurve_SECG_PRIME_160R2,          /* ECCurve_SECG_PRIME_160R2 */
 -    &ecCurve_SECG_PRIME_192K1,          /* ECCurve_SECG_PRIME_192K1 */
 -    &ecCurve_SECG_PRIME_224K1,          /* ECCurve_SECG_PRIME_224K1 */
--    &ecCurve_SECG_PRIME_256K1,          /* ECCurve_SECG_PRIME_256K1 */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
++    NULL,                               /* ECCurve_noName */
+     &ecCurve_SECG_PRIME_256K1,          /* ECCurve_SECG_PRIME_256K1 */
 -    &ecCurve_SECG_CHAR2_113R1,          /* ECCurve_SECG_CHAR2_113R1 */
 -    &ecCurve_SECG_CHAR2_113R2,          /* ECCurve_SECG_CHAR2_113R2 */
 -    &ecCurve_SECG_CHAR2_131R1,          /* ECCurve_SECG_CHAR2_131R1 */
@@ -1947,47 +1990,6 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl-curve.h b/src/jdk.
 -    &ecCurve_BrainpoolP320r1,           /* ECCurve_BrainpoolP320r1 */
 -    &ecCurve_BrainpoolP384r1,           /* ECCurve_brainpoolP384r1 */
 -    &ecCurve_BrainpoolP512r1,           /* ECCurve_brainpoolP512r1 */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
-+    NULL,                               /* ECCurve_noName */
 +    NULL,                               /* ECCurve_noName */
 +    NULL,                               /* ECCurve_noName */
 +    NULL,                               /* ECCurve_noName */
@@ -2157,7 +2159,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/ecl.c b/src/jdk.crypto
 diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c
 --- a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c
 +++ b/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c
-@@ -73,87 +73,12 @@
+@@ -73,87 +73,13 @@
  /* NOTE: prime192v1 is the same as secp192r1, prime256v1 is the
   * same as secp256r1
   */
@@ -2180,7 +2182,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -CONST_OID secgECsecp192k1[] = { SECG_OID, 0x1f };
 -CONST_OID secgECsecp224k1[] = { SECG_OID, 0x20 };
 -CONST_OID secgECsecp224r1[] = { SECG_OID, 0x21 };
--CONST_OID secgECsecp256k1[] = { SECG_OID, 0x0a };
+ CONST_OID secgECsecp256k1[] = { SECG_OID, 0x0a };
  CONST_OID secgECsecp384r1[] = { SECG_OID, 0x22 };
  CONST_OID secgECsecp521r1[] = { SECG_OID, 0x23 };
  
@@ -2245,7 +2247,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
  #define OI(x) { siDEROID, (unsigned char *)x, sizeof x }
  #ifndef SECOID_NO_STRINGS
  #define OD(oid,tag,desc,mech,ext) { OI(oid), tag, desc, mech, ext }
-@@ -174,30 +99,18 @@
+@@ -174,30 +100,18 @@
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
  
@@ -2288,7 +2290,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
      OD( ansiX962prime256v1, ECCurve_NIST_P256,
          "ANSI X9.62 elliptic curve prime256v1 (aka secp256r1, NIST P-256)",
          CKM_INVALID_MECHANISM,
-@@ -208,46 +121,34 @@
+@@ -208,42 +122,24 @@
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
  
@@ -2328,10 +2330,6 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 -        "SECG elliptic curve secp160k1",
 -        CKM_INVALID_MECHANISM,
 -        INVALID_CERT_EXTENSION ),
--    OD( secgECsecp256k1, ECCurve_SECG_PRIME_256K1,
--        "SECG elliptic curve secp256k1",
--        CKM_INVALID_MECHANISM,
--        INVALID_CERT_EXTENSION ),
 +    { { siDEROID, NULL, 0 }, ECCurve_noName,
 +        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 +    { { siDEROID, NULL, 0 }, ECCurve_noName,
@@ -2350,25 +2348,23 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
 +        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 +    { { siDEROID, NULL, 0 }, ECCurve_noName,
 +        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-+    { { siDEROID, NULL, 0 }, ECCurve_noName,
-+        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-     { { siDEROID, NULL, 0 }, ECCurve_noName,
-         "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
-     { { siDEROID, NULL, 0 }, ECCurve_noName,
-@@ -256,16 +157,42 @@
+     OD( secgECsecp256k1, ECCurve_SECG_PRIME_256K1,
+         "SECG elliptic curve secp256k1",
+         CKM_INVALID_MECHANISM,
+@@ -256,16 +152,50 @@
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 -    OD( secgECsect163r2, ECCurve_NIST_B163,
 -        "SECG elliptic curve sect163r2 (aka NIST B-163)",
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
++    { { siDEROID, NULL, 0 }, ECCurve_noName,
++        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 +    { { siDEROID, NULL, 0 }, ECCurve_noName,
 +        "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
 +    { { siDEROID, NULL, 0 }, ECCurve_noName,
@@ -2414,7 +2410,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
          CKM_INVALID_MECHANISM,
          INVALID_CERT_EXTENSION ),
      { { siDEROID, NULL, 0 }, ECCurve_noName,
-@@ -275,79 +202,7 @@
+@@ -275,79 +205,7 @@
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
@@ -2495,7 +2491,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
  };
  
  static SECOidData ANSI_oids[] = {
-@@ -355,78 +210,46 @@
+@@ -355,78 +213,46 @@
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
  
      /* ANSI X9.62 named elliptic curves (characteristic two field) */
@@ -2606,7 +2602,7 @@ diff --git a/src/jdk.crypto.ec/share/native/libsunec/impl/oid.c b/src/jdk.crypto
  };
  
  static SECOidData BRAINPOOL_oids[] = {
-@@ -446,31 +269,14 @@
+@@ -446,31 +272,14 @@
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },
      { { siDEROID, NULL, 0 }, ECCurve_noName,
          "Unknown OID", CKM_INVALID_MECHANISM, INVALID_CERT_EXTENSION },


### PR DESCRIPTION
2022-07-04  Andrew John Hughes  <gnu_andrew@member.fsf.org>

	* NEWS: Updated.
	* patches/gh001-3curve.patch: Renamed
	from pr3818-3curve.patch. Updated to
	apply after JDK-8226374, including
	removal of unsupported curve from
	jdk.tls.disabledAlgorithms.
	* patches/gh001-4curve.patch: Likewise
	for the 4 curve version, renamed from
	pr3818-4curve.patch

Fixes: #1 