### PR TITLE
GH006: Update jstaptest.pl.in to use modern JDK file structure

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-02-07  Andrew John Hughes  <gnu_andrew@member.fsf.org>
+
+	GH006: Update jstaptest.pl.in to use
+	modern JDK file structure
+	* test/tapset/jstaptest.pl.in:
+	Fix paths in java_exec and jvm_dir
+	to match modern JDK structure.
+
 2022-07-12  Andrew John Hughes  <gnu_andrew@member.fsf.org>
 
 	GH003: Import ECC test patch from Zdeněk Žamberský

--- a/test/tapset/jstaptest.pl.in
+++ b/test/tapset/jstaptest.pl.in
@@ -916,9 +916,9 @@ sub clean_up {
 #     files/directories within $JAVA_HOME.
 sub set_java_vars {
     my ($_java_home, $_arch_dir) = @_;
-    $java_exec = "$_java_home/jre/bin/java";
+    $java_exec = "$_java_home/bin/java";
     $javac_exec = "$_java_home/bin/javac";
-    $jvm_dir = "$_java_home/jre/lib/$_arch_dir/server";
+    $jvm_dir = "$_java_home/lib/server";
     $jvm_so = "$jvm_dir/libjvm.so";
     push(@include_dirs, "-I$_java_home/include");
     push(@include_dirs, "-I$_java_home/include/linux");


### PR DESCRIPTION
2025-02-07  Andrew John Hughes  <gnu_andrew@member.fsf.org>

	GH006: Update jstaptest.pl.in to use
	modern JDK file structure
	* test/tapset/jstaptest.pl.in: Fix paths in `java_exec` and `jvm_dir` to match modern JDK structure.

Resolves: #6